### PR TITLE
[ENG-1105] Add all Open API specs to workflow

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -23,6 +23,10 @@ jobs:
       mode: direct
       openapi_docs: |
         - https://api2.eu1.stackone-dev.com/oas/stackone.json
+        - https://api2.eu1.stackone-dev.com/oas/hris.json
+        - https://api2.eu1.stackone-dev.com/oas/ats.json
+        - https://api2.eu1.stackone-dev.com/oas/crm.json
+        - https://api2.eu1.stackone-dev.com/oas/marketing.json
       publish_typescript: true
       speakeasy_version: latest
     secrets:


### PR DESCRIPTION
All our open api specs were added to the workflow to generate the SDK for all our public and documented endpoints.