### PR TITLE
Add actions permissions to workflow configuration

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,5 +1,6 @@
 name: Generate
 permissions:
+  actions: write
   checks: write
   contents: write
   pull-requests: write


### PR DESCRIPTION
In order for the workflow to be able to run and change a protected branch, the actions permissions were added to the yml configuration file.