### PR TITLE
chore: change speakeasy workflow to pr mode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @StackOneHQ/engineering

--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -20,7 +20,7 @@ jobs:
       force: ${{ github.event.inputs.force }}
       languages: |
         - typescript
-      mode: direct
+      mode: pr
       openapi_docs: |
         - https://api2.eu1.stackone.com/oas/stackone.json
         - https://api2.eu1.stackone.com/oas/hris.json
@@ -30,6 +30,6 @@ jobs:
       publish_typescript: true
       speakeasy_version: latest
     secrets:
-      github_access_token: ${{ secrets.SPEAKEASYBOT_TOKEN }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  on:
+  push:
+    paths:
+      - 'RELEASES.md'
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the SDK publishing workflow to handle publishing to the package managers
+    with:
+      publish_typescript: true
+      create_release: true
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
To allow the protection of the main branch and only allow changes in the SDK when a PR is created and merged in `main`, the workflow was changed to PR mode, which means that instead of pushing directly the changes to main, it will instead create a PR that needs review from the StackOne team.

To support the publish of the package automatically when the PR is merged, a new publish workflow was added.

Also, to improve branch protection, a CODEOWNERS file was added that specify StackOne/engineering as the code owners.