### PR TITLE
chore: add speakeasy key to publish workflow

### DIFF
--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -9,10 +9,11 @@ name: Publish
 
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the SDK publishing workflow to handle publishing to the package managers
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
     with:
       publish_typescript: true
       create_release: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
The speakeasy api key was missing in the publish workflow so it was added.