### PR TITLE
chore: change schedule of the generate workflow

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -12,7 +12,7 @@ permissions:
         type: boolean
         default: false
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 9 * * 1
 jobs:
   generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14


### PR DESCRIPTION
This PR changes the schedule to run every monday at 9am instead of every day.

The current daily schedule is creating some issues:
- Too many versions of the SDK being generate without significant changes
- If we don't merge a specific generated version, we will miss some versions when publishing to NPM registry (e.g. we just published v0.10.7 but the previous version was v0.10.4 because the others were squashed during the weekend).

If we want to publish a version outside of the weekly schedule we can still generate a version on demand