### PR TITLE
chore: update to speakeasy TS v2 generator

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -38,3 +38,4 @@ typescript:
   packageName: '@stackone/stackone-client-ts'
   published: true
   repoSubDirectory: .
+  templateVersion: v2


### PR DESCRIPTION
Update the template version to v2 which will make the next SDKs to be regenerated with TS v2 generator.

More info here:
https://www.speakeasyapi.dev/post/introducing-universal-ts