### PR TITLE
chore: restore pagination readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ run();
 * [proxyRequest](docs/sdks/proxy/README.md#proxyrequest) - Proxy Request
 <!-- End Available Resources and Operations [operations] -->
 
-
-
-<!-- No Pagination -->
+<!-- Start Pagination -->
+<!-- End Pagination -->
 
 <!-- Start Error Handling [errors] -->
 ## Error Handling


### PR DESCRIPTION
Restore the pagination section in README. This will be automatically filled by speakeasy when generating the SDK based on the open api configuration.