### PR TITLE
Revert: revert changes to security.ts

### DIFF
--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -167,8 +167,8 @@ function applyBearer(
     state.headers[spec.fieldName] = value;
 }
 export function resolveGlobalSecurity(security: Partial<shared.Security> | null | undefined) {
-    return resolveSecurity([
-        { value: security?.password, fieldName: "password", type: "http:basic" },
-        { value: security?.username, fieldName: "username", type: "http:basic" },
-    ]);
+    return resolveSecurity(
+        [{ value: security?.password, fieldName: "password", type: "http:basic" }],
+        [{ value: security?.username, fieldName: "username", type: "http:basic" }],
+    );
 }


### PR DESCRIPTION
Reverting this change that was introduced on the last generation as it seems to be responsible for breaking the latest SDK release (with which I can only get 403s back). I tested by applying this change in our sandbox app and verified it fixed the 403s. This is a temporary revert until speakeasy confirms/fixes the root cause.